### PR TITLE
Documents in penalty group require `inPenaltyGroup` boolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsp-validation",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Validation package for Roadside Payments",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ValidationModels/penaltyGroupValidation.js
+++ b/src/ValidationModels/penaltyGroupValidation.js
@@ -1,13 +1,20 @@
 import Joi from 'joi';
 import PenaltyValidation from './penaltyValidation';
 
+const extendPenaltyDocumentSchema = () => {
+	return PenaltyValidation.request.concat(Joi.object({
+		Value: Joi.object({
+			inPenaltyGroup: Joi.boolean().required(),
+		}),
+	}));
+};
+
 export default {
 	request: Joi.object().keys({
 		Timestamp: Joi.number().required(),
 		Location: Joi.string().required(),
 		SiteCode: Joi.number().required(),
 		VehicleRegistration: Joi.string().required(),
-		Penalties: Joi.array().items(PenaltyValidation.request).required(),
+		Penalties: Joi.array().items(extendPenaltyDocumentSchema()).required(),
 	}),
 };
-

--- a/src/Validations/penaltyGroups.unit.js
+++ b/src/Validations/penaltyGroups.unit.js
@@ -20,6 +20,7 @@ describe('penaltyGroupValidation', () => {
 					Origin: 'APP',
 					Value: {
 						penaltyType: 'FPN',
+						inPenaltyGroup: true,
 						paymentStatus: 'UNPAID',
 						paymentToken: 'XXX generated paymentToken XXX',
 						formNo: 'FPN 11/08',


### PR DESCRIPTION
Adding a requirement that all penalty documents validated strictly as part of a penalty group must have a boolean property `inPenaltyGroup` in their value