### PR TITLE
Improvements around penalty document schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsp-validation",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Validation package for Roadside Payments",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ValidationModels/penaltyGroupValidation.js
+++ b/src/ValidationModels/penaltyGroupValidation.js
@@ -1,20 +1,12 @@
 import Joi from 'joi';
 import PenaltyValidation from './penaltyValidation';
 
-const extendPenaltyDocumentSchema = () => {
-	return PenaltyValidation.request.concat(Joi.object({
-		Value: Joi.object({
-			inPenaltyGroup: Joi.boolean().required(),
-		}),
-	}));
-};
-
 export default {
 	request: Joi.object().keys({
 		Timestamp: Joi.number().required(),
 		Location: Joi.string().required(),
 		SiteCode: Joi.number().required(),
 		VehicleRegistration: Joi.string().required(),
-		Penalties: Joi.array().items(extendPenaltyDocumentSchema()).required(),
+		Penalties: Joi.array().items(PenaltyValidation.request).required(),
 	}),
 };

--- a/src/ValidationModels/penaltyValidation.js
+++ b/src/ValidationModels/penaltyValidation.js
@@ -41,6 +41,7 @@ const valueSchema = {
 	placeWhereIssued: Joi.string(),
 	officerID: Joi.string().required(),
 	siteCode: Joi.number().integer().required(),
+	inPenaltyGroup: Joi.boolean().required(),
 };
 
 export default {

--- a/src/Validations/penaltyDocuments.unit.js
+++ b/src/Validations/penaltyDocuments.unit.js
@@ -27,6 +27,7 @@ describe('penaltyValidation', () => {
 				paymentDate: 1518480000,
 				officerID: 'Z7F6yxnw--6DJf4sLsxjg_S-3Gvrl5MxV-1iY7RRNiA',
 				paymentStatus: 'PAID',
+				inPenaltyGroup: false,
 			},
 			Hash: 'c3c7581adeec5585e953e2a613c26986ce35a733f17947921cb828749c1aaf22',
 		};


### PR DESCRIPTION
* Require `inPenaltyGroup` in individual penalty documents, not just
  those created as part of a penalty group
* Bump version to `1.5.3`