### PR TITLE
RSP-1823: Add payment start time fields to doc and group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsp-validation",
-  "version": "1.5.16",
+  "version": "1.5.17",
   "description": "Validation package for Roadside Payments",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ValidationModels/penaltyGroupValidation.js
+++ b/src/ValidationModels/penaltyGroupValidation.js
@@ -9,5 +9,8 @@ export default {
 		SiteCode: Joi.number().required(),
 		VehicleRegistration: Joi.string().required().regex(/^[0-9A-Z,]*$/),
 		Penalties: Joi.array().items(PenaltyValidation.request).required(),
+		fpnPaymentStartTime: Joi.number(),
+		imPaymentStartTime: Joi.number(),
+		cdnPaymentStartTime: Joi.number()
 	}),
 };

--- a/src/ValidationModels/penaltyValidation.js
+++ b/src/ValidationModels/penaltyValidation.js
@@ -45,6 +45,7 @@ const valueSchema = {
 	officerID: Joi.string().regex(/^[a-zA-Z0-9_-]*$/).required(),
 	siteCode: Joi.number().integer().required(),
 	inPenaltyGroup: Joi.boolean().required(),
+	paymentStartTime: Joi.number(),
 };
 
 export default {

--- a/src/Validations/penaltyDocuments.unit.js
+++ b/src/Validations/penaltyDocuments.unit.js
@@ -291,4 +291,12 @@ describe('penaltyValidation', () => {
 			assertInvalidPenaltyDocument(exampleDocument);
 		});
 	});
+
+	describe('when paymentStartTime is valid', () => {
+		it('should pass validation', () => {
+			exampleDocument.Value.paymentStartTime = 1559572341.039;
+			const retObj = penaltyValidation(exampleDocument);
+			expect(retObj.valid).toBe(true);
+		});
+	})
 });

--- a/src/Validations/penaltyGroups.unit.js
+++ b/src/Validations/penaltyGroups.unit.js
@@ -48,4 +48,14 @@ describe('penaltyGroupValidation', () => {
 			expect(valid).toBe(false);
 		});
 	});
+
+	describe('when paymentStartTime is valid', () => {
+		it('should pass validation', () => {
+			penaltyGroup.fpnPaymentStartTime = 1559572341.039;
+			penaltyGroup.imPaymentStartTime = 1559572341.039;
+			penaltyGroup.cdnPaymentStartTime = 1559572341.039;
+			const retObj = penaltyGroupValidation(penaltyGroup);
+			expect(retObj.valid).toBe(true);
+		});
+	})
 });


### PR DESCRIPTION
Added to be able to detect when the payment process has started to facilitate showing a message to the user telling them a payment may be pending when another session is active.