### PR TITLE
feat: Package is built prior to publish, then uploaded to NPM.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.1
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.3
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.1
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.1
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.1
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
     with:
       upload_artifact: true
       build_folder: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.3
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
     with:
       upload_artifact: true
       build_folder: package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,22 @@ on:
 
 jobs:
   lint:
-    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-lint.yaml@v2.2
 
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.2
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.2
     with:
       upload_artifact: true
       build_folder: package
       build_folder_path: dist
       retention_days: 3
       build_command: build
+      

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,15 @@ on:
 
 jobs:
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.2
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
     with:
       upload_artifact: true
       build_folder: package
@@ -23,7 +23,7 @@ jobs:
 
   publish:
     needs: [test, security, build]
-    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@feature/rsp-2105-update-publish-workflow
+    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
     with:
       node_version: '16.x'
       download_artifact: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,19 @@
 name: NPM Publish
 
 on:
-  release:
-    types: [published]
+  push:
 
 jobs:
   test:
-    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.2
 
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.2
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   build:
-    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.2
     with:
       upload_artifact: true
       build_folder: package
@@ -24,11 +23,12 @@ jobs:
 
   publish:
     needs: [test, security, build]
-    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
+    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@feature/rsp-2105-update-publish-workflow
     with:
       node_version: '16.x'
       download_artifact: true
       build_folder: package
       build_folder_path: dist
+      args: "--dry-run"
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,30 @@ on:
     types: [published]
 
 jobs:
+  test:
+    uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
+
+  security:
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  build:
+    uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
+    with:
+      upload_artifact: true
+      build_folder: package
+      build_folder_path: dist
+      retention_days: 3
+      build_command: build
+
   publish:
-    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.1
+    needs: [test, security, build]
+    uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
     with:
       node_version: '16.x'
+      download_artifact: true
+      build_folder: package
+      build_folder_path: dist
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: NPM Publish
 
 on:
-  push:
+  release:
+    types: [published]
 
 jobs:
   test:
@@ -29,6 +30,6 @@ jobs:
       download_artifact: true
       build_folder: package
       build_folder_path: dist
-      args: "--dry-run"
+      args: "--access=public"
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -8,8 +8,4 @@ test
 .eslintrc
 .nvmrc
 package-lock.json
-dist/Validations/cpmsTransaction.unit.js
-dist/Validations/payments.unit.js
-dist/Validations/penaltyDocuments.unit.js
-dist/Validations/penaltyGroups.unit.js
-dist/Validations/tokens.unit.js
+dist/**/*.unit.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log
+.DS_Store
+.github
+src
+test
+.babelrc
+.eslintrc
+.nvmrc
+package-lock.json
+dist/Validations/cpmsTransaction.unit.js
+dist/Validations/payments.unit.js
+dist/Validations/penaltyDocuments.unit.js
+dist/Validations/penaltyGroups.unit.js
+dist/Validations/tokens.unit.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/rsp-validation",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Validation package for Roadside Payments",
   "main": "dist/index.js",
   "engine": {


### PR DESCRIPTION
## Description
- Updated release.yaml to use changes in org .github workflows
- Updated ci.yaml to use latest workflow versions
- Added .npmignore to control what is built in final package
- .npmignore includes all files except dist folder, which is built prior to upload

Related issue: [RSP-2105](https://dvsa.atlassian.net/browse/RSP-2105?atlOrigin=eyJpIjoiMDlmZTE3ZTkyYjBlNGQwMjhhYTllNTljYzM2NTVjZTYiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
