### PR TITLE
feat: Ignore dev dependencies from Snyk security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
   security:
     uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    with:
+      args: --all-projects
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
## Description

- Ignore dev dependenices when running Snyk scan in CI

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
