### PR TITLE
feat: Ignore dev dependencies from NPM publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,11 @@ jobs:
 
   security:
     uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2.3
+    with:
+      args: --all-projects
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
+    
   build:
     uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
     with:


### PR DESCRIPTION
## Description

- Added args to the security step in the release workflow to ignore dev dependencies and pass Snyk scanning.

Related issue: [RSP-2158](https://dvsa.atlassian.net/browse/RSP-2158?atlOrigin=eyJpIjoiMmY5NWE1M2RjMDg5NDg0YWE0MDA4MjgwNzg0YjllODAiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
