### PR TITLE
feat: Updated the max amount of payment items allowed

### DIFF
--- a/src/ValidationModels/cpmsTransactionValidation.js
+++ b/src/ValidationModels/cpmsTransactionValidation.js
@@ -54,6 +54,6 @@ export default {
 			city: Joi.string().required(),
 			postcode: Joi.string().required(),
 		}),
-		payment_data: Joi.array().items(Joi.object(paymentDataSchema)).min(1).max(10),
+		payment_data: Joi.array().items(Joi.object(paymentDataSchema)).min(1),
 	}),
 };

--- a/src/Validations/cpmsTransaction.js
+++ b/src/Validations/cpmsTransaction.js
@@ -2,7 +2,7 @@ import cpmsTransactionValidation from '../ValidationModels/cpmsTransactionValida
 
 export default (data) => {
 	const schema = cpmsTransactionValidation.request;
-	const joiResult = schema.validate(data);
+	const joiResult = schema.validate(data, { errors: { wrap: { label: '' } } });
 	if (joiResult.error) {
 		return {
 			valid: false,

--- a/src/Validations/payments.js
+++ b/src/Validations/payments.js
@@ -4,7 +4,7 @@ import paymentValidation from '../ValidationModels/paymentValidation';
 
 export default (data) => {
 	const schema = paymentValidation.request;
-	const validationResult = schema.validate(data);
+	const validationResult = schema.validate(data, { errors: { wrap: { label: '' } } });
 	if (validationResult.error) {
 		return {
 			valid: false,

--- a/src/Validations/penaltyDocuments.js
+++ b/src/Validations/penaltyDocuments.js
@@ -2,7 +2,7 @@ import penaltyDocumentValidation from '../ValidationModels/penaltyValidation';
 
 export default (data) => {
 	const schema = penaltyDocumentValidation.request;
-	const validationResult = schema.validate(data);
+	const validationResult = schema.validate(data, { errors: { wrap: { label: '' } } });
 	if (validationResult.error) {
 		return {
 			valid: false,

--- a/src/Validations/penaltyGroups.js
+++ b/src/Validations/penaltyGroups.js
@@ -2,7 +2,7 @@ import PenaltyGroupValidation from '../ValidationModels/penaltyGroupValidation';
 
 export default (data) => {
 	const schema = PenaltyGroupValidation.request;
-	const joiResult = schema.validate(data);
+	const joiResult = schema.validate(data, { errors: { wrap: { label: '' } } });
 	if (joiResult.error) {
 		return {
 			valid: false,


### PR DESCRIPTION
## Description

- CPMS penalty items was getting rejected due to a max value of 10 being set
- Updated the error message logs so instead of `\"key_name\"` being escaped in logs, now logs out `key_name` with no label wrap

Related issue: [RSP-1998](https://dvsa.atlassian.net/browse/RSP-1998)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
