### PR TITLE
feat: implementation of release-please action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,29 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: rsp-validation
+
   test:
     uses: dvsa/.github/.github/workflows/nodejs-test.yaml@v2.3
 
@@ -17,6 +36,8 @@ jobs:
     
   build:
     uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
+    if: ${{ needs.release-please.outputs.release-created }}
+    needs: [ release-please, test, security ]
     with:
       upload_artifact: true
       build_folder: package
@@ -25,7 +46,8 @@ jobs:
       build_command: build
 
   publish:
-    needs: [test, security, build]
+    needs: [release-please, test, security, build]
+    if: ${{ needs.release-please.outputs.release-created }}
     uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
     with:
       node_version: '16.x'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: NPM Publish
+name: Release
 
 on:
   release:


### PR DESCRIPTION
## Description

- Changed workflow name from NPM Publish to Release
- Changed to run on pushes to main branch (ie when a PR is merged)
- Added release-please action to create release PRs
- Modified build and publish steps to require release-created tag from release-please, meaning they will only run when a release occurs

Related issue: [RSP-2170](https://dvsa.atlassian.net/browse/RSP-2170?atlOrigin=eyJpIjoiODEwMWNiYzJmODU5NGEwZjgwZmQ1OTQxODk1MTVmY2QiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
