### PR TITLE
fix: Change workflow branch from main to master

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

- The workflow has been changed to run on pushes to the default branch, however this branch was misnamed in the changes. It has been corrected to 'master' from 'main'.

Related issue: [RSP-2170](https://dvsa.atlassian.net/browse/RSP-2170?atlOrigin=eyJpIjoiODEwMWNiYzJmODU5NGEwZjgwZmQ1OTQxODk1MTVmY2QiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
