### PR TITLE
docs: Add publish step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ If using Node.JS:
 
     npm test
 
+## Publishing Package
+
+Uses GitHub to package and release. GitHub will create a release job merge requests which bumps the version in the package.json based on the conventional commits. If there are breaking changes, make sure the commit specifies this.
+
+Merging the release PR will trigger the release action which publishes a new version to NPM automatically. NPM token must be in GitHub with permission to publish to DVSA npm org.


### PR DESCRIPTION
## Description

- Include publishing to npm org in README

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
