### PR TITLE
ci: corrected if statements to reference release-please output steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     
   build:
     uses: dvsa/.github/.github/workflows/nodejs-build.yaml@v2.3
-    if: ${{ needs.release-please.outputs.release-created }}
+    if: ${{ needs.release-please.outputs.release_created }}
     needs: [ release-please, test, security ]
     with:
       upload_artifact: true
@@ -47,7 +47,7 @@ jobs:
 
   publish:
     needs: [release-please, test, security, build]
-    if: ${{ needs.release-please.outputs.release-created }}
+    if: ${{ needs.release-please.outputs.release_created }}
     uses: dvsa/.github/.github/workflows/nodejs-publish.yaml@v2.3
     with:
       node_version: '16.x'


### PR DESCRIPTION
## Description

- When the release.yaml was [last updated](https://github.com/dvsa/rsp-validation-package/commit/7827669f1dadcb1cbf176ce77c787c54f8ed25e0), the if statements in the build and publish steps were referencing an output that had been typed in correctly (dashes instead of underscores).
- This PR fixes that issue, changing them from dashes *to* underscores.
- Evidence of working (and hitting the build and publish steps) can be seen in the [forked repo for testing](https://github.com/dvsa/rsp-validation-package-rp-test/actions/runs/3957996321).

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
