### PR TITLE
fix: spelling errors in cpmsTransaction.unit.js

### DIFF
--- a/src/Validations/cpmsTransaction.unit.js
+++ b/src/Validations/cpmsTransaction.unit.js
@@ -113,7 +113,7 @@ describe('cpmsTransactionValidation', () => {
 		});
 	});
 
-	context('given a cheque payment object is  being validated', () => {
+	context('given a cheque payment object is being validated', () => {
 		let chequePaymentObject;
 
 		beforeEach(() => {
@@ -134,7 +134,7 @@ describe('cpmsTransactionValidation', () => {
 		beforeEach(() => {
 			postalOrderPaymentObject = { ...cpmsPayloadSamplePostal };
 		});
-		describe('when a valid postal order payment obejct is passed for validation', () => {
+		describe('when a valid postal order payment object is passed for validation', () => {
 			it('should return valid set to true', () => {
 				const validationResult = cpmsTransactionValidation(postalOrderPaymentObject);
 				expect(validationResult.error.message).toBeUndefined();


### PR DESCRIPTION
## Description

- Line 116 contained an unnecessary space, which was removed to improve readability.
- Line 137 contained object spelt incorrectly, which has been fixed.

Related issue: n/a

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
