### PR TITLE
fix: Release workflow build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       build-folder: package
       build-folder-path: dist
       retention-days: 3
-      build-command: build
+      build-command: npm run build
 
   publish:
     needs: [release-please, test, security, build]


### PR DESCRIPTION
## Description

Fixes the release workflow build job.

BEGIN_COMMIT_OVERRIDE
chore: release 2.0.0

Release-As: 2.0.0
END_COMMIT_OVERRIDE

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
