### PR TITLE
Fix penalty document reg no validation

### DIFF
--- a/src/ValidationModels/penaltyValidation.js
+++ b/src/ValidationModels/penaltyValidation.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-const regNoValidation = Joi.string().min(1).max(10)
-	.regex(/^[A-Z0-9a-z]{1,10}$/);
+const regNoValidation = Joi.string().min(1).max(21)
+	.regex(/^[A-Z0-9a-z]{1,21}$/);
 
 const driverSchema = {
 	name: Joi.string(),

--- a/src/Validations/penaltyDocuments.unit.js
+++ b/src/Validations/penaltyDocuments.unit.js
@@ -196,9 +196,9 @@ describe('penaltyValidation', () => {
 			assertInvalidPenaltyDocument(exampleDocument, 'Value.vehicleDetails.regNo');
 		});
 	});
-	describe('when regNo is greater than 10 characters', () => {
+	describe('when regNo is greater than 21 characters', () => {
 		it('should return a fail with message', () => {
-			exampleDocument.Value.vehicleDetails.regNo = 'ABC123DEF45';
+			exampleDocument.Value.vehicleDetails.regNo = 'ABC123DEF45ABC123DEF45';
 			assertInvalidPenaltyDocument(exampleDocument, 'Value.vehicleDetails.regNo');
 		});
 	});
@@ -215,9 +215,9 @@ describe('penaltyValidation', () => {
 			expect(valid).toBe(true);
 		});
 	});
-	describe('when VehicleRegistration is greater than 10 characters', () => {
+	describe('when VehicleRegistration is greater than 21 characters', () => {
 		it('should return a fail with message', () => {
-			exampleDocument.VehicleRegistration = 'ABC123DEF45';
+			exampleDocument.VehicleRegistration = 'ABC123DEF45ABC123DEF45';
 			assertInvalidPenaltyDocument(exampleDocument, 'VehicleRegistration');
 		});
 	});


### PR DESCRIPTION
## Description

As per conversation with Leanne Thompson to match search amended the Reg validation to include trailer reg (21 chars)

Related issue: [rsp-2275](https://dvsa.atlassian.net/browse/RSP-2275)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
